### PR TITLE
Add .pch files to objective-c grammar.

### DIFF
--- a/grammars/objective-c.cson
+++ b/grammars/objective-c.cson
@@ -1,6 +1,7 @@
 'fileTypes': [
   'm'
   'h'
+  'pch'
 ]
 'name': 'Objective-C'
 'patterns': [


### PR DESCRIPTION
This adds support for precompiled header files.
