### PR TITLE
Added .x file type (Logos preprocessor)

### DIFF
--- a/grammars/objective-c.cson
+++ b/grammars/objective-c.cson
@@ -5,6 +5,7 @@
   'pch'
   'xm'
   'xmi'
+  'x'
 ]
 'name': 'Objective-C'
 'patterns': [


### PR DESCRIPTION
`xm` and `xmi` are not the only supported file extensions by the Logos interpreter, there's also `x`.
