### PR TITLE
Rename scope name: objc++ -> objcpp

### DIFF
--- a/grammars/objective-c++.cson
+++ b/grammars/objective-c++.cson
@@ -1,4 +1,4 @@
-'scopeName': 'source.objc++'
+'scopeName': 'source.objcpp'
 'fileTypes': [
   'mm'
   'M'
@@ -6,8 +6,14 @@
 ]
 'name': 'Objective-C++'
 'patterns': [
+
+  # TODO - remove once the rename from 'c++' to 'cpp' has been released
   {
     'include': 'source.c++'
+  }
+
+  {
+    'include': 'source.cpp'
   }
   {
     'include': 'source.objc'

--- a/scoped-properties/language-objective-c.cson
+++ b/scoped-properties/language-objective-c.cson
@@ -1,4 +1,4 @@
-'.source.objc, .source.objc\\+\\+':
+'.source.objc, .source.objcpp':
   'editor':
     'completions': [
       'retain'
@@ -32,6 +32,6 @@
       'NSMutableString'
       'NSString'
     ]
-'.source.objc\\+\\+, .source.objc':
+'.source.objcpp, .source.objc':
   'editor':
     'foldEndPattern': '(?<!\\*)\\*\\*/|^\\s*\\}|^@end\\b'

--- a/snippets/language-objective-c.cson
+++ b/snippets/language-objective-c.cson
@@ -1,4 +1,4 @@
-'.source.objc, .source.objc\\+\\+':
+'.source.objc, .source.objcpp':
   '#import <>':
     'prefix': 'Imp'
     'body': '#import <${1:Cocoa/Cocoa.h}>'

--- a/spec/objective-c-spec.coffee
+++ b/spec/objective-c-spec.coffee
@@ -28,11 +28,11 @@ describe 'Language-Objective-C', ->
 
   describe "Objective-C++", ->
     beforeEach ->
-      grammar = atom.grammars.grammarForScopeName('source.objc++')
+      grammar = atom.grammars.grammarForScopeName('source.objcpp')
 
     it 'parses the grammar', ->
       expect(grammar).toBeTruthy()
-      expect(grammar.scopeName).toBe 'source.objc++'
+      expect(grammar.scopeName).toBe 'source.objcpp'
 
     it 'tokenizes classes', ->
       lines = grammar.tokenizeLines '''
@@ -45,5 +45,5 @@ describe 'Language-Objective-C', ->
         @end
       '''
 
-      expect(lines[0][2]).toEqual value: 'Thing1', scopes: ["source.objc++", "meta.class-struct-block.c++", "entity.name.type.c++"]
-      expect(lines[4][3]).toEqual value: 'Thing2', scopes: ["source.objc++", "meta.interface-or-protocol.objc", "entity.name.type.objc"]
+      expect(lines[0][2]).toEqual value: 'Thing1', scopes: ["source.objcpp", "meta.class-struct-block.c++", "entity.name.type.c++"]
+      expect(lines[4][3]).toEqual value: 'Thing2', scopes: ["source.objcpp", "meta.interface-or-protocol.objc", "entity.name.type.objc"]


### PR DESCRIPTION
Refs atom/language-c#54
