### PR TITLE
:bug: Fix syntax error

### DIFF
--- a/grammars/objective-c.cson
+++ b/grammars/objective-c.cson
@@ -66,15 +66,24 @@
         'name': 'punctuation.definition.string.end.objc'
     'name': 'string.quoted.double.objc'
     'patterns': [
+      { 'match': '\\\\(\\\\|[abefnprtv\'"?]|[0-3]\\d{,2}|[4-7]\\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})'
+        'name': 'constant.character.escape.objc'
+      }
       {
-        'include': 'source.c#string_escaped_char'
+        'match': '\\\\.'
+        'name': 'invalid.illegal.unknown-escape.objc'
       }
       {
         'match': '(?x)%\n\t\t\t\t\t\t(\\d+\\$)?                             # field (argument #)\n\t\t\t\t\t\t[#0\\- +\']*                          # flags\n\t\t\t\t\t\t((-?\\d+)|\\*(-?\\d+\\$)?)?              # minimum field width\n\t\t\t\t\t\t(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?         # precision\n\t\t\t\t\t\t[@]                                  # conversion type\n\t\t\t\t\t'
         'name': 'constant.other.placeholder.objc'
       }
       {
-        'include': 'source.c#string_placeholder'
+        'match': '(?x)%\n    \t\t\t\t\t\t(\\d+\\$)?                         # field (argument #)\n    \t\t\t\t\t\t[#0\\- +\']*                      # flags\n    \t\t\t\t\t\t[,;:_]?                              # separator character (AltiVec)\n    \t\t\t\t\t\t((-?\\d+)|\\*(-?\\d+\\$)?)?              # minimum field width\n    \t\t\t\t\t\t(\\.((-?\\d+)|\\*(-?\\d+\\$)?)?)?         # precision\n    \t\t\t\t\t\t(hh|h|ll|l|j|t|z|q|L|vh|vl|v|hv|hl)? # length modifier\n    \t\t\t\t\t\t[diouxXDOUeEfFgGaACcSspn%]           # conversion type\n    \t\t\t\t\t'
+        'name': 'constant.other.placeholder.c'
+      }
+      {
+        'match': '%'
+        'name': 'invalid.illegal.placeholder.c'
       }
     ]
   }


### PR DESCRIPTION
According to
http://manual.macromates.com/en/language_grammars#language_rules,
keyword “include” is not suggested to be used for referencing rule
declared in other file. These includes are replaced by the rules that
they referenced to. This patch also fix #7 .