### PR TITLE
Clarify "Strings File" is for Objective-C

### DIFF
--- a/grammars/strings file.cson
+++ b/grammars/strings file.cson
@@ -2,7 +2,7 @@
 'fileTypes': [
   'strings'
 ]
-'name': 'Strings File'
+'name': 'Strings File (Objective-C)'
 'patterns': [
   {
     'begin': '/\\*'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change
Clarify that strings file grammar name is for Objective-C

For example, this is what you currently see with the grammar selector:

![grammar-selector](https://github-slack.s3.amazonaws.com/monosnap/untitled__worktest-tree-sitter_2019-02-20_20-48-30.png)

This would now say `Strings File (Objective-C)`.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

More clear that the Strings File grammar is for Objective-C.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

N/A
<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

N/A

<!-- Enter any applicable Issues here -->
